### PR TITLE
use location.replace for redirecting; alpha release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/ruled-router",
-  "version": "0.2.15",
+  "version": "0.2.16-a1",
   "description": "Router parser designed and customized for web apps in JiMeng.io",
   "main": "./lib/path-parser.js",
   "types": "./lib/path-parser.d.ts",

--- a/src/dom.tsx
+++ b/src/dom.tsx
@@ -31,7 +31,7 @@ export let HashRedirect: FC<{
     clearInterval(timing.current);
 
     timing.current = setTimeout(() => {
-      window.location.hash = props.to;
+      window.location.replace(`${window.location.origin}#${props.to}`);
     }, delay);
 
     return () => {


### PR DESCRIPTION
`location.replace` overwrites current history. when use use back button to navigate back, he/she will not run being redirected again.